### PR TITLE
Bugfixes

### DIFF
--- a/components/Comment/Comment.jsx
+++ b/components/Comment/Comment.jsx
@@ -160,6 +160,7 @@ export default class Comment extends React.Component {
           saveResource={this.saveEdited}
           existing={content}
           submitButtonText='Save'
+          clearAfterSave={false}
         />
 
       </View>

--- a/components/Comment/Comment.jsx
+++ b/components/Comment/Comment.jsx
@@ -65,7 +65,7 @@ export default class Comment extends React.Component {
     var commentId = data._id;
     var newComment = {
       ...data,
-      content: newContent
+      ...newContent
     }
 
     this.closeEditingModal();

--- a/components/ContentBar/ContentBar.jsx
+++ b/components/ContentBar/ContentBar.jsx
@@ -69,6 +69,7 @@ export default class ContentBar extends React.Component {
           saveResource={this.saveResource}
           submitButtonText={this.props.submitButtonText}
           showToolbar={this.props.showModalToolbar}
+          clearAfterSave={true}
         />
       </View>
     )

--- a/components/CreateResourceModal/CreateResourceModal.jsx
+++ b/components/CreateResourceModal/CreateResourceModal.jsx
@@ -20,8 +20,8 @@ export default class CreateResourceModal extends React.Component {
   }
 
   saveResource = () => {
-    const { saveResource } = this.props;
-    this.setState({ resourceText: '', image: null });
+    const { saveResource, clearAfterSave } = this.props;
+    if (clearAfterSave) this.setState({ resourceText: '', image: null });
     return saveResource && saveResource({content: this.state.resourceText, image: this.state.image});
   }
 
@@ -30,8 +30,8 @@ export default class CreateResourceModal extends React.Component {
   }
 
   onCancel = () => {
-    const { onClose } = this.props;
-    this.setState({ resourceText: '', image: null });
+    const { onClose, clearAfterSave } = this.props;
+    if (clearAfterSave) this.setState({ resourceText: '', image: null });
     onClose();
   }
 

--- a/components/Post/Post.jsx
+++ b/components/Post/Post.jsx
@@ -277,6 +277,7 @@ export default class Post extends React.Component {
           saveResource={this.saveEdited}
           existing={content}
           submitButtonText='Save'
+          clearAfterSave={false}
         />
       </View>
     )

--- a/components/Post/Post.jsx
+++ b/components/Post/Post.jsx
@@ -67,9 +67,13 @@ export default class Post extends React.Component {
   }
 
   saveEdited = (newContent) => {
-    const { updatePost, data } = this.props;
+    let { updatePost, data } = this.props;
     var postId = data._id;
-    data.content = newContent;
+    data = {
+      ...data,
+      content: newContent.content,
+      image: newContent.image || data.image
+    }
     this.closeEditingModal();
 
     updatePost && updatePost(postId, data, 'editPost');

--- a/views/Comments/Comments.jsx
+++ b/views/Comments/Comments.jsx
@@ -143,7 +143,7 @@ export default class CommentsView extends React.Component {
               var updatedPost = {
                 ...postData,
                 comments: postData.comments.map(comment => {
-                  if (comment._id === id) return commentContent;
+                  if (comment._id === id) return data;
                   return comment;
                 })
               };


### PR DESCRIPTION
- Editing comments would crash the app as we weren't handling data in a consistent shape
- Editing, saving or cancelling, then opening edit again would lead to an empty text field - added a prop to `CreateResourceModal` that dictates whether content should be erased after cancel/save that fixes this issue.

#120 