### PR TITLE
Update notification list automitcally

### DIFF
--- a/views/Home/Home.jsx
+++ b/views/Home/Home.jsx
@@ -7,6 +7,7 @@ import NotificationList from "../../components/NotificationList/NotificationList
 import HomeTabBar from "./HomeTabBar/HomeTabBar";
 import style from "./HomeStyle";
 import api from '../../ApiClient';
+import { Notifications } from 'expo';
 
 export default class HomeView extends React.Component {
 
@@ -30,6 +31,20 @@ export default class HomeView extends React.Component {
       this.setState({ channels: response, loading: false });
     })
     .catch(err => console.error(err));
+
+    this.notificationSubscription = Notifications.addListener(this.handleNewNotification);
+  }
+
+  handleNewNotification = () => {
+    api.get(
+      '/users/loggedInUser',
+      { Authorization: `Bearer ${this.state.token}`}
+    )
+    .then(user => {
+      if (user._id) {
+        this.setState({notifications: user.notifications});
+      }
+    }).catch(err => console.log(err));
   }
 
   onPressChannel = (channelId, channelName) => {

--- a/views/Home/Home.jsx
+++ b/views/Home/Home.jsx
@@ -142,7 +142,7 @@ export default class HomeView extends React.Component {
                   <Text style={style.markAllSeenText}>Mark all as seen</Text>
                 </TouchableOpacity>
                 <NotificationList
-                  notifications={this.state.notifications}
+                  notifications={this.state.notifications.slice(0, 30)}
                   onPressNotif={this.onPressNotif}
                 />
               </View>


### PR DESCRIPTION
Currently the only way for your new notifications to show up is if you close/reopen the app. This sucks, so this PR fixes that so the notification list automatically updates as push notifications come in

It also limits nofication list to 30 so it doesn't get slow switching between channel list / notification list. I don't think anyone cares about anything over 30 notifs ago but could be wrong. LMK how people feel