### PR TITLE
Added relative dates to posts

### DIFF
--- a/components/NotificationList/NotificationList.jsx
+++ b/components/NotificationList/NotificationList.jsx
@@ -31,8 +31,15 @@ export default class NotificationList extends React.Component {
     } else {
       return (
         this.props.notifications.map((notif, key) => {
-          const createdAt = date.format(notif.createdAt, 'ddd MMM Do [at] h:mma');
-          
+          var createdAt;
+          if(date.isPast(date.addWeeks(notif.createdAt,1))){
+            //If the post is more than a week old, display date
+            createdAt = date.format(notif.createdAt, 'ddd MMM Do');
+          }else{
+            //Display how long ago the post was made
+            createdAt = date.distanceInWordsToNow(notif.createdAt, {addSuffix: true});
+          }
+
           return (
             <TouchableOpacity 
               key={key}

--- a/components/Post/Post.jsx
+++ b/components/Post/Post.jsx
@@ -266,7 +266,17 @@ export default class Post extends React.Component {
     // TODO: implement
     var authorPhoto = author.profilePicture;
 
-    createdAt = date.format(createdAt, 'ddd MMM Do [at] h:mma');
+    if(this.props.showFullDate){
+      //If in comment view, view full date including timestamp
+      createdAt = date.format(createdAt, 'ddd MMM Do [at] h:mma');
+    }else if(date.isPast(date.addWeeks(createdAt,1))){
+      //If the post is more than a week old, display date
+      createdAt = date.format(createdAt, 'ddd MMM Do');
+    }else{
+      //Display how long ago the post was made
+      createdAt = date.distanceInWordsToNow(createdAt, {addSuffix: true});
+    }
+
     var numComments = comments ? comments.length : 0;
     var likes = likes ? likes : 0;
 

--- a/views/Comments/Comments.jsx
+++ b/views/Comments/Comments.jsx
@@ -237,6 +237,7 @@ export default class CommentsView extends React.Component {
               enableDeleting={loggedInUser.isAdmin}
               loggedInUser={loggedInUser}
               showUserProfile={this.showUserProfile}
+              showFullDate={true}
             />
             <ScrollView>
               {comments.length ?

--- a/views/Feed/Feed.jsx
+++ b/views/Feed/Feed.jsx
@@ -281,6 +281,7 @@ export default class FeedView extends React.Component {
         enableEditing={enableEditing}
         enableDeleting={loggedInUser.isAdmin}
         showUserProfile={this.showUserProfile}
+        showFullDate={false}
       />
     );
   }


### PR DESCRIPTION
Relative dates if post is less than a week old. Users can view full date by clicking on the post.
Issue #110