### PR TITLE
Update android permissions to comply with new Google Play Permissions

### DIFF
--- a/app.json
+++ b/app.json
@@ -17,7 +17,11 @@
         "foregroundImage": "./assets/icon-front.png",
         "backgroundImage": "./assets/icon-back.png"
       },
-      "versionCode": 2
+      "permissions": [
+        "CAMERA",
+        "CAMERA_ROLL"
+      ],
+      "versionCode": 3
     },
     "notification": {
       "icon": "./assets/icon-notification.png",


### PR DESCRIPTION
Policy update requires we can't use SMS or the app will be removed. We're not using it anyway, but all permissions are requested by default unless you specifically ask.

https://android-developers.googleblog.com/2018/10/providing-safe-and-secure-experience.html