### PR TITLE
Aded temporary android fix for image caching

### DIFF
--- a/helpers/imageCache.js
+++ b/helpers/imageCache.js
@@ -1,14 +1,18 @@
 import { Cache } from "react-native-cache";
 import ApiClient from '../ApiClient';
-import {AsyncStorage} from 'react-native';
+import {AsyncStorage, MemoryStore, Platform} from 'react-native';
 import date from 'date-fns';
+
+var backend
+if(Platform.OS == 'android') backend = MemoryStore
+else backend = AsyncStorage
 
 const profilePicCache = new Cache({
 	namespace: "skybunk-profile-pictures",
 	policy: {
 		maxEntries: 30
 	},
-	backend: AsyncStorage
+	backend: backend
 });
 
 const postPicCache = new Cache({
@@ -16,7 +20,7 @@ const postPicCache = new Cache({
 	policy: {
 		maxEntries: 15
 	},
-	backend: AsyncStorage
+	backend: backend
 });
 
 module.exports = {


### PR DESCRIPTION
Changed android from Async storage to MemoryStore. Memory store goes to volatile memory, so it will only cache items until the app restarts. But it will prevent the crashes that android users have been encountering.

Future fix will involve writing our own image cache that restricts the size of the cache instead of the amount of items. the module we are using is a little shit and very simple, so we should just write our own.