### PR TITLE
invalid notifications fix

### DIFF
--- a/components/NotificationList/NotificationList.jsx
+++ b/components/NotificationList/NotificationList.jsx
@@ -40,6 +40,12 @@ export default class NotificationList extends React.Component {
             createdAt = date.distanceInWordsToNow(notif.createdAt, {addSuffix: true});
           }
 
+          // Slight hack (Neil): don't advertise notifications for deleted posts.
+          // Ideally there should be server-side logic to clean out all invalid notifications.
+          if (!notif.data.post) {
+            return null;
+          }
+
           return (
             <TouchableOpacity 
               key={key}


### PR DESCRIPTION
Really quick patchfix for notifications advertising posts that have been deleted - should get rid of the good 'ol "This post doesn't seem to exist :/" for repeated notifications.

There should be server logic to clean out notifications that contain invalid post data; the `/user/loggedInUser` endpoint would be one place to filter notis before giving them to the client, but a notification cleaning service of some sort would be even better. Not super important and this gets the job done so I didn't invest that much effort, sorry :P 