### PR TITLE
Fixed bug with likes on secondary pages

### DIFF
--- a/components/Post/Post.jsx
+++ b/components/Post/Post.jsx
@@ -147,7 +147,6 @@ export default class Post extends React.Component {
     if (data.usersLiked.find((user) => user._id === loggedInUser._id)) {
       data.likes--;
       data.usersLiked = _.filter(data.usersLiked, user => user._id !== loggedInUser._id);
-      data.isLiked = false;
     } else {
       data.likes++;
       data.usersLiked.push({
@@ -155,7 +154,6 @@ export default class Post extends React.Component {
         firstname: loggedInUser.firstName,
         lastName: loggedInUser.lastName
       });
-      data.isLiked = true;
     }
 
     if (data.likes < 0) data.likes = 0; // (Grebel's a positive community, come on!)
@@ -165,14 +163,11 @@ export default class Post extends React.Component {
 
   generateLikesList = () => {
     let {
-      usersLiked,
-      isLiked
+      usersLiked
     } = this.props.data;
 
-    const { loggedInUser } = this.props;
-
-    if (isLiked) {
-      usersLiked = usersLiked.filter(user => user._id !== loggedInUser._id);
+    if (usersLiked.filter(e => e._id == this.props.loggedInUser._id).length) {
+      usersLiked = usersLiked.filter(user => user._id !== this.props.loggedInUser._id);
       usersLiked.unshift({ firstName: 'You' }); // a wee hack
     }
 
@@ -232,21 +227,20 @@ export default class Post extends React.Component {
     var {
       author,
       content,
-      likes,
       usersLiked,
-      isLiked,
       comments,
       createdAt,
       tags,
     } = data;
-
+    const isLiked = usersLiked.filter(e => e._id == this.props.loggedInUser._id).length > 0;
     var likeIcon = isLiked ? require('../../assets/liked-cookie.png') : require('../../assets/cookie-icon.png');
 
     if (isLiked) {
-      usersLiked = usersLiked.filter(user => user._id !== loggedInUser._id);
+      usersLiked = usersLiked.filter(user => user._id !== this.props.loggedInUser._id);
       usersLiked.unshift({ firstName: 'You' });
     }
     var likesDialog;
+    var likes = usersLiked.length;
     if (likes === 0) {
       likesDialog = "No cookies yet";
     } else if (likes === 1) {
@@ -277,7 +271,6 @@ export default class Post extends React.Component {
     }
 
     var numComments = comments ? comments.length : 0;
-    var likes = likes ? likes : 0;
 
     return (
       <View>

--- a/views/Comments/Comments.jsx
+++ b/views/Comments/Comments.jsx
@@ -70,10 +70,6 @@ export default class CommentsView extends React.Component {
 
     await ApiClient.get(postUri, {authorized: true})
       .then(response => {
-        if (response.usersLiked.find(user => user._id === loggedInUser._id)) {
-          response.isLiked = true;
-        } else response.isLiked = false;
-
         this.setState({ postData: response });
 
         // Ensure feed view is up-to-date with current:

--- a/views/Feed/Feed.jsx
+++ b/views/Feed/Feed.jsx
@@ -276,6 +276,15 @@ export default class FeedView extends React.Component {
       loadingPage: true,
     }, state =>
         ApiClient.get(this.getUri(), {authorized: true, headers: { 'page': this.state.page }}).then(response => {
+          // This doesn't look like it does anything, but it does. ¯\_(ツ)_/¯
+          const loggedInUser = this.props.navigation.getParam('loggedInUser');
+          var posts = _.map(response, post => {
+            if (post.usersLiked.find((user) => user._id === loggedInUser._id)) {
+              post.isLiked = true;
+            } else post.isLiked = false;
+            return post;
+          });
+
           this.setState({
             posts: [...this.state.posts, ...response],
             loadingPage: false,

--- a/views/Feed/Feed.jsx
+++ b/views/Feed/Feed.jsx
@@ -86,14 +86,6 @@ export default class FeedView extends React.Component {
     const loggedInUser = this.props.navigation.getParam('loggedInUser');
     await ApiClient.get(this.getUri(), {authorized: true})
       .then(response => {
-        // This doesn't look like it does anything, but it does. ¯\_(ツ)_/¯
-        var posts = _.map(response, post => {
-          if (post.usersLiked.find((user) => user._id === loggedInUser._id)) {
-            post.isLiked = true;
-          } else post.isLiked = false;
-          return post;
-        });
-
         this.setState({
           posts: response,
           loading: false,
@@ -276,14 +268,6 @@ export default class FeedView extends React.Component {
       loadingPage: true,
     }, state =>
         ApiClient.get(this.getUri(), {authorized: true, headers: { 'page': this.state.page }}).then(response => {
-          // This doesn't look like it does anything, but it does. ¯\_(ツ)_/¯
-          const loggedInUser = this.props.navigation.getParam('loggedInUser');
-          var posts = _.map(response, post => {
-            if (post.usersLiked.find((user) => user._id === loggedInUser._id)) {
-              post.isLiked = true;
-            } else post.isLiked = false;
-            return post;
-          });
 
           this.setState({
             posts: [...this.state.posts, ...response],


### PR DESCRIPTION
When loading a post from a secondary page, the isLiked field was not getting updated.